### PR TITLE
Declare required providers for Istio submodules

### DIFF
--- a/regional/manifests/providers.tofu
+++ b/regional/manifests/providers.tofu
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+
+    # Kubernetes Provider
+    # https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs
+
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}

--- a/regional/providers.tofu
+++ b/regional/providers.tofu
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+
+    # Google Cloud Platform Provider
+    # https://search.opentofu.org/provider/hashicorp/google/latest/docs
+
+    google = {
+      source = "hashicorp/google"
+    }
+
+    # Helm Provider
+    # https://search.opentofu.org/provider/hashicorp/helm/latest/docs
+
+    helm = {
+      source = "hashicorp/helm"
+    }
+
+    # Kubernetes Provider
+    # https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs
+
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}

--- a/shared/helpers.tofu
+++ b/shared/helpers.tofu
@@ -2,5 +2,5 @@
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "core_helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//child?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1"  # v0.3.1
+  source = "github.com/osinfra-io/pt-arche-core-helpers//child?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1" # v0.3.1
 }

--- a/tests/default.tftest.hcl
+++ b/tests/default.tftest.hcl
@@ -54,5 +54,5 @@ run "default_regional" {
 }
 
 variables {
-  project     = "mock-project"
+  project = "mock-project"
 }


### PR DESCRIPTION
## What
- Add required_providers declarations for the regional module: google, helm, and kubernetes.
- Add a required_providers declaration for the regional/manifests module: kubernetes.
- Include tofu fmt updates produced by pre-commit.

## Why
This lets pt-pneuma pass explicit per-cluster provider instances via providers maps without OpenTofu warning about undefined provider references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to include the required cloud, deployment, and cluster providers.
  * Made minor formatting-only adjustments in shared configuration and test settings.
  * No user-facing behavior or feature changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->