### PR TITLE
Skip DNS records for member team clusters

### DIFF
--- a/main.tofu
+++ b/main.tofu
@@ -151,7 +151,7 @@ resource "google_compute_ssl_policy" "istio_gateway" {
 # https://search.opentofu.org/provider/hashicorp/google/latest/docs/resources/dns_record_set
 
 resource "google_dns_record_set" "istio_gateway_mcis" {
-  for_each = var.gateway_dns
+  for_each = var.gke_fleet_host_project_id == "" ? var.gateway_dns : {}
 
   managed_zone = each.value.managed_zone
   name         = "${each.key}."


### PR DESCRIPTION
Member team module instances (e.g., pt-kryptos) have `gke_fleet_host_project_id != ""` which disables the global address via `lifecycle { enabled = false }`. However `google_dns_record_set.istio_gateway_mcis` was still using `for_each = var.gateway_dns` and referencing the disabled address — leaving orphaned DNS records pointing at an unconfigured IP with no MCI backend.

**Fix:** Gate the `for_each` on `gke_fleet_host_project_id == ""` so DNS records are only created for the hub/gateway team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted DNS record creation so gateway DNS entries are only provisioned when the host project setting is not configured, preventing unintended resource creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->