### PR TITLE
Deduplicate test fixture variables using shared symlink

### DIFF
--- a/tests/fixtures/default/regional/variables.tofu
+++ b/tests/fixtures/default/regional/variables.tofu
@@ -1,15 +1,1 @@
-# Input Variables
-# https://opentofu.org/docs/language/values/variables
-
-variable "gateway_dns" {
-  description = "Map of DNS configurations for the Istio Gateway"
-  type = map(object({
-    managed_zone = string
-    project      = string
-  }))
-}
-
-variable "project" {
-  description = "The GCP project ID"
-  type        = string
-}
+../shared/variables.tofu

--- a/tests/fixtures/default/shared/variables.tofu
+++ b/tests/fixtures/default/shared/variables.tofu
@@ -1,0 +1,15 @@
+# Input Variables
+# https://opentofu.org/docs/language/values/variables
+
+variable "gateway_dns" {
+  description = "Map of DNS configurations for the Istio Gateway"
+  type = map(object({
+    managed_zone = string
+    project      = string
+  }))
+}
+
+variable "project" {
+  description = "The GCP project ID"
+  type        = string
+}

--- a/tests/fixtures/default/variables.tofu
+++ b/tests/fixtures/default/variables.tofu
@@ -1,15 +1,1 @@
-# Input Variables
-# https://opentofu.org/docs/language/values/variables
-
-variable "gateway_dns" {
-  description = "Map of DNS configurations for the Istio Gateway"
-  type = map(object({
-    managed_zone = string
-    project      = string
-  }))
-}
-
-variable "project" {
-  description = "The GCP project ID"
-  type        = string
-}
+shared/variables.tofu


### PR DESCRIPTION
`tests/fixtures/default/variables.tofu` and `tests/fixtures/default/regional/variables.tofu` were byte-for-byte identical. Moved the canonical copy to `tests/fixtures/default/shared/variables.tofu` and replaced both with relative symlinks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Terraform/OpenTofu fixture variable definitions by relocating shared configuration inputs to the shared fixture.
  * Removed duplicate variable definitions from the default and regional fixtures.
  * No end-user functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->