### PR TITLE
Suppress expected Istio analyzer warnings

### DIFF
--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -200,6 +200,10 @@ resource "kubernetes_manifest" "istio_gateway" {
           "cloud.google.com/app-protocols"  = jsonencode({ "https" = "HTTPS" })
           "cloud.google.com/backend-config" = jsonencode({ "default" = "istio-gateway-backend" })
           "cloud.google.com/neg"            = jsonencode({ "ingress" = true })
+
+          # Suppress IST0170: The MCS only exports port 443 (not status-port 15021) by design,
+          # so Istio sees inconsistent ports across clusters. This is expected.
+          "galley.istio.io/analyze-suppress" = "IST0170"
         }
 
         labels = {

--- a/regional/manifests/main.tofu
+++ b/regional/manifests/main.tofu
@@ -24,6 +24,11 @@ resource "kubernetes_manifest" "istio_cluster_services_destination_rule" {
     kind       = "DestinationRule"
 
     metadata = {
+      annotations = {
+        # IST0174: Wildcard host doesn't match specific services; this is intentional
+        # for applying cluster-wide traffic policies.
+        "galley.istio.io/analyze-suppress" = "IST0174"
+      }
       name      = "cluster-services"
       namespace = "istio-system"
     }
@@ -157,6 +162,11 @@ resource "kubernetes_manifest" "istio_kubernetes_default_destination_rule" {
     kind       = "DestinationRule"
 
     metadata = {
+      annotations = {
+        # IST0174: kubernetes.default.svc is the Kubernetes API server, not part of
+        # the mesh. This rule disables mTLS to ensure API server access works.
+        "galley.istio.io/analyze-suppress" = "IST0174"
+      }
       name      = "kubernetes-default"
       namespace = "istio-system"
     }


### PR DESCRIPTION
## Summary

Suppress expected warnings from `istioctl analyze` that don't indicate real problems.

## Warnings Suppressed

| Warning | Resource | Reason |
|---------|----------|--------|
| IST0170 | `Service gateway-istio` | MCS only exports port 443 (not status-port 15021) by design |
| IST0174 | `DestinationRule cluster-services` | Wildcard `*.svc.cluster.local` is intentional for cluster-wide locality failover |
| IST0174 | `DestinationRule kubernetes-default` | `kubernetes.default.svc` is the API server, not in mesh; rule disables mTLS |

Added `galley.istio.io/analyze-suppress` annotations to each resource.

Closes #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Istio configuration to suppress known, non-actionable validation warnings for gateway and destination rule settings.
  * Reduced misleading analysis alerts related to port consistency, wildcard hosts, and the Kubernetes API service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->