### PR TITLE
Fix perpetual gateway listener plan drift

### DIFF
--- a/regional/locals.tofu
+++ b/regional/locals.tofu
@@ -23,9 +23,9 @@ locals {
         }
       }
 
-      # hostname is intentionally omitted (not set to null): a listener without a hostname is
-      # catch-all, and the kubernetes_manifest provider treats an explicit null as a
-      # known-after-apply value, which produces a perpetual in-place diff on every plan.
+      # hostname is intentionally absent — the field is omitted, not set to null. A listener with
+      # no hostname is catch-all, and the kubernetes_manifest provider treats an explicit null as
+      # a known-after-apply value, which produces a perpetual in-place diff on every plan.
       name     = "https"
       port     = 443
       protocol = "HTTPS"

--- a/regional/locals.tofu
+++ b/regional/locals.tofu
@@ -23,7 +23,9 @@ locals {
         }
       }
 
-      hostname = null
+      # hostname is intentionally omitted (not set to null): a listener without a hostname is
+      # catch-all, and the kubernetes_manifest provider treats an explicit null as a
+      # known-after-apply value, which produces a perpetual in-place diff on every plan.
       name     = "https"
       port     = 443
       protocol = "HTTPS"


### PR DESCRIPTION
## What changed

The `https` gateway listener set `hostname = null`. The `kubernetes_manifest` provider treats an explicit `null` as a *known-after-apply* value, so every `tofu plan` reported `module.kubernetes_istio[...].kubernetes_manifest.istio_gateway will be updated in-place` to re-add `hostname` — perpetual drift that never converges.

## Why it's safe

A Gateway API listener with no `hostname` is already catch-all (identical behavior to `hostname: null`). The live object never stores the null key anyway, so omitting the field entirely removes the diff with **zero behavior change**.

## Verification

- Confirmed the live `gateway` object has no `hostname` on the `https` listener.
- `pre-commit run -a` clean (fmt, validate, test 2/2, scan).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented perpetual provider diffs for gateway listeners while preserving catch-all listener behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->